### PR TITLE
Fix invalid pattern matching for 401 errors

### DIFF
--- a/lib/ueberauth/strategy/linked_in.ex
+++ b/lib/ueberauth/strategy/linked_in.ex
@@ -124,7 +124,7 @@ defmodule Ueberauth.Strategy.LinkedIn do
       {:ok, %OAuth2.Response{status_code: status_code, body: _body}} when status_code not in 200..299 ->
         set_errors!(conn, [error("LinkedIn API error", "Failed to fetch user data")])
 
-      {:ok, %OAuth2.Response{status_code: 401, body: _body}} ->
+      {:error, %OAuth2.Response{status_code: 401, body: _body}} ->
         set_errors!(conn, [error("token", "unauthorized")])
 
       {:error, %OAuth2.Response{status_code: 403, body: body}} ->


### PR DESCRIPTION
👋🏼 Hi there!
I've been experimenting a lot of "Unknown error" lately while authenticating. While debugging the error, I found out the pattern match is incorrect since it is returning a

```elixir
{:error, %OAuth2.Response{status_code: 401}}
```

rather than a `{:ok, ...}` value.

This PR fixes this issue.
