### PR TITLE
Pass everything as query params

### DIFF
--- a/lib/ueberauth/strategy/linked_in.ex
+++ b/lib/ueberauth/strategy/linked_in.ex
@@ -5,10 +5,10 @@ defmodule Ueberauth.Strategy.LinkedIn do
   @user_url "https://api.linkedin.com/v2/userinfo"
 
   use Ueberauth.Strategy,
-      uid_field: :id,
-      default_scope: "openid profile email",
-      send_redirect_uri: true,
-      oauth2_module: Ueberauth.Strategy.LinkedIn.OAuth
+    uid_field: :id,
+    default_scope: "openid profile email",
+    send_redirect_uri: true,
+    oauth2_module: Ueberauth.Strategy.LinkedIn.OAuth
 
   alias Ueberauth.Auth.Info
   alias Ueberauth.Auth.Credentials
@@ -98,7 +98,7 @@ defmodule Ueberauth.Strategy.LinkedIn do
       first_name: user["given_name"],
       last_name: user["family_name"],
       image: user["picture"],
-      email: user["email"],
+      email: user["email"]
     }
   end
 
@@ -109,7 +109,7 @@ defmodule Ueberauth.Strategy.LinkedIn do
     %Extra{
       raw_info: %{
         token: conn.private.linkedin_token,
-        user: conn.private.linkedin_user,
+        user: conn.private.linkedin_user
       }
     }
   end
@@ -121,7 +121,8 @@ defmodule Ueberauth.Strategy.LinkedIn do
       {:ok, %OAuth2.Response{status_code: 200, body: user}} ->
         put_private(conn, :linkedin_user, user)
 
-      {:ok, %OAuth2.Response{status_code: status_code, body: _body}} when status_code not in 200..299 ->
+      {:ok, %OAuth2.Response{status_code: status_code, body: _body}}
+      when status_code not in 200..299 ->
         set_errors!(conn, [error("LinkedIn API error", "Failed to fetch user data")])
 
       {:ok, %OAuth2.Response{status_code: 401, body: _body}} ->

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule UeberauthLinkedIn.MixProject do
       app: :ueberauth_linkedin,
       version: "0.10.8",
       elixir: "~> 1.15",
-      build_embedded: Mix.env == :prod,
+      build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       name: "UeberauthLinkedIn",
       description: description(),


### PR DESCRIPTION
Hey, 

I looked into this issue more: https://github.com/utf26/ueberauth_linkedin/issues/4 

I found that we are experiencing this: https://github.com/decioferreira/omniauth-linkedin-oauth2/issues/17
Some solutions are mentioned there and here: https://stackoverflow.com/questions/66830621/linkedin-api-the-token-used-in-the-request-has-been-revoked-by-the-user

I tried out adding a little sleep, that helped a bit, but I did not like that option.

I changed the way the accessToken call is made to pass everything in query params (as suggested in the provided links) instead of the body.
This seems to work reliably.

The relevant changes are in `lib/ueberauth/strategy/linked_in/o_auth.ex` the rest are from the formatter.

Thank you